### PR TITLE
Fix subject escaping

### DIFF
--- a/exportarnotas-main-v1/exportarnotas-editar/index.php
+++ b/exportarnotas-main-v1/exportarnotas-editar/index.php
@@ -268,7 +268,7 @@ echo $OUTPUT->header();
 
         <div class="mb-3">
             <label for="subject" class="form-label">Asunto</label>
-            <input type="text" class="form-control" id="subject" name="subject" required value="Calificaciones del curso <?php echo $course->fullname; ?>">
+            <input type="text" class="form-control" id="subject" name="subject" required value="Calificaciones del curso <?php echo s($course->fullname); ?>">
         </div>
 
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- escape course fullname in subject input to avoid breaking HTML when course name has special characters

## Testing
- `php -l exportarnotas-main-v1/exportarnotas-editar/index.php`
- `php -l exportarnotas-main-v1/exportarnotas-editar/lib.php`
- `php -l exportarnotas-main-v1/exportarnotas-editar/db/access.php`
- `php -l exportarnotas-main-v1/exportarnotas-editar/version.php`


------
https://chatgpt.com/codex/tasks/task_b_6852bf1d543c8329a2baa2b4267878c8